### PR TITLE
update cosign version to fix signature issue

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
         with:
-          cosign-release: 'v1.11.0'
+          cosign-release: 'v1.13.1'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
According to:
 https://github.com/slsa-framework/slsa-github-generator/issues/1163
it was due to a key rotation error and shouldn't happen on newer release of cosign - so we are going to the bleeding edge and seeing if it fixes it.

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>