### PR TITLE
Fix "address already in use" error that emerges after restarting app

### DIFF
--- a/server.go
+++ b/server.go
@@ -65,14 +65,10 @@ func dial(unixSocketPath string, timeout time.Duration) (*grpc.ClientConn, error
 
 // Start the gRPC server of the device plugin
 func (m *SmarterDevicePlugin) Start() error {
-	err := m.cleanup()
-	if err != nil {
-		return err
-	}
-
 	sock, err := net.Listen("unix", m.socket)
 	if err != nil {
-		return err
+		cleanupErr :=  m.cleanup()
+		return fmt.Errorf("unable to bind to socket: %v, cleanup err is %v", err, cleanupErr)
 	}
 
 	m.server = grpc.NewServer([]grpc.ServerOption{}...)


### PR DESCRIPTION
Removing unix socket doesn't make it available right away, so first iteration of re-starting server after releasing newer version of the app may end with "address is already in use" error (Short version is, the kernel has a TIME_WAIT state when it is closing a TCP connection graceful, meaning you can’t reuse it until that is finished).

This patch covers the error: we only return error and call cleanup if listener object could not be created